### PR TITLE
docs: expand folder structure for configs, models, tests, and repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,49 @@ HTTP Request → Controller → Service → Repository (Dapper, SQL Server) → 
 ## 📂 โครงสร้างโฟลเดอร์
 
 ```markdown
-
-src/
+Dotnet8RestApiJwtTemplate.Api/
 ┣ Attributes/        # Custom Attributes (Validation, Authorization, etc.)
 ┣ Clients/           # External Clients (HTTP Client, gRPC, etc.)
-┣ Configs/           # Configuration & Options (DatabaseOptions, JwtOptions, SqlConnectionFactory, etc.)
+┣ Configs/           # Configuration & Options
+┃ ┣ AppSettings.cs
+┃ ┣ DatabaseOptions.cs
+┃ ┣ JwtOptions.cs
+┃ ┣ ISqlConnectionFactory.cs
+┃ ┣ SqlConnectionFactory.cs
+┃ ┣ UrlService.cs
+┃ ┗ KebabCaseParameterTransformer.cs
 ┣ Constants/         # Constant Values (Claim keys, default values)
-┣ Controllers/       # API Controllers (AuthController, HealthCheckController, etc.)
+┣ Controllers/       # API Controllers
+┃ ┣ AuthenController.cs
+┃ ┗ HealthCheckController.cs
 ┣ DTOs/              # Data Transfer Objects (DB ↔ DTO ↔ Models)
 ┣ Enums/             # Enumerations (Status, Role, etc.)
 ┣ Models/            # Request/Response Models (used at HTTP layer)
+┃ ┣ AuthenModel/
+┃ ┃ ┣ AuthenRequest.cs
+┃ ┃ ┗ AuthenResponse.cs
+┃ ┗ HealthCheckModel/
+┃   ┗ HealthCheckResponse.cs
 ┣ Repositories/      # Data Access Layer (Dapper queries to SQL Server)
+┃ ┗ HealthCheckRepository/
+┃   ┣ IHealthCheckRepository.cs
+┃   ┗ HealthCheckRepository.cs
 ┣ Services/          # Business Logic Layer
+┃ ┣ AuthenService/
+┃ ┃ ┣ IAuthenService.cs
+┃ ┃ ┗ AuthenService.cs
+┃ ┗ HealthCheckService/
+┃ ┃ ┣ IHealthCheckService.cs
+┃ ┃ ┗ HealthCheckService.cs
 ┗ Utilities/         # Helpers/Utilities (e.g., ZipJsonExporter)
-tests/
-┗ UnitTests/         # xUnit tests (AAA pattern)
+Dotnet8RestApiJwtTemplate.Test/
+┣ Controllers/       # Unit tests for Controllers (AAA pattern)
+┃ ┣ AuthControllerTests.cs
+┃ ┗ HealthCheckControllerTests.cs
+┣ Services/          # Unit tests for Services (AAA pattern)
+┃ ┣ AuthenServiceTests.cs
+┃ ┗ HealthCheckServiceTests.cs
+┗ Dotnet8RestApiJwtTemplate.Test.csproj
 
 ````
 


### PR DESCRIPTION
## Summary
- detail configuration and model files in API folder structure
- list repository subdirectory and key files
- document controller and service test directories

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c81d3dad48832bb9ea397f34b0f1d0